### PR TITLE
Fix crash on existing mdns entry

### DIFF
--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -47,7 +47,7 @@ export class Registry {
             var service: Service = this
             registry.probe(registry.server.mdns, this, (exists: any) => {
                 if(exists) {
-                    service.stop(service)
+                    service.stop()
                     console.log(new Error('Service name is already in use on the network'))
                     return
                 }
@@ -185,7 +185,9 @@ export class Registry {
             (services as Array<Service>).forEach(function (service) {
                 service.published = false
             })
-            if (callback) callback.apply(null, arguments)
+            if (typeof callback === "function") {
+                callback.apply(null, arguments)
+            }
         })
     }
 }


### PR DESCRIPTION
On quick restarts with the probe default enabled, my application just died with an uncaught exception:

```
[2021-07-29T16:38:48.363Z] [ERROR] Uncaught Exception {
  err: TypeError: callback.apply is not a function
      at /snapshot/Valetudo_Github/node_modules/bonjour-service/dist/lib/registry.js:135:26
      at processTicksAndRejections (node:internal/process/task_queues:83:21),
  origin: 'uncaughtException'
}
```

Looking at the original non-typescript code, the previous code seems to be wrong
https://github.com/watson/bonjour/blob/bdc467a4f3c7b9fe8bc54468b6fc4d80b8f1c098/lib/registry.js#L46-L64