### PR TITLE
Add Error Callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,15 @@ instance.find({ type: 'http' }, function (service) {
 ### Initializing
 
 ```js
-var instance = new Bonjour({ options })
+var instance = new Bonjour({ options }, errorCallback)
 ```
 
 The `options` are optional and will be used when initializing the
 underlying multicast-dns server. For details see [the multicast-dns
 documentation](https://github.com/mafintosh/multicast-dns#mdns--multicastdnsoptions).
+
+`errorCallback` is an optional callback used to gracefully handle errors that would otherwise
+crash the process. While not being strictly required, providing this is highly recommended
 
 ### Publishing
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,16 +12,17 @@ export class Bonjour {
     /**
      * Setup bonjour service with optional config
      * @param opts ServiceConfig | undefined
+     * @param errorCallback Function | undefined
      */
-    constructor(opts?: ServiceConfig | undefined) {
-        this.server     = new Server(opts)
+    constructor(opts?: ServiceConfig | undefined, errorCallback?: Function | undefined) {
+        this.server     = new Server(opts, errorCallback)
         this.registry   = new Registry(this.server)
     }
 
     /**
      * Publish a service for the device with options
-     * @param opts 
-     * @returns 
+     * @param opts
+     * @returns
      */
     public publish(opts: ServiceConfig): Service {
         return this.registry.publish(opts)
@@ -30,7 +31,7 @@ export class Bonjour {
     /**
      * Unpublish all services for the device
      * @param callback
-     * @returns 
+     * @returns
      */
     public unpublishAll(callback?: CallableFunction | undefined): void {
         return this.registry.unpublishAll(callback)
@@ -40,7 +41,7 @@ export class Bonjour {
      * Find services on the network with options
      * @param opts BrowserConfig
      * @param onup Callback when up event received
-     * @returns 
+     * @returns
      */
     public find(opts: BrowserConfig | undefined = undefined, onup?: (...args: any[]) => void): Browser {
         return new Browser(this.server.mdns, opts, onup)
@@ -51,7 +52,7 @@ export class Bonjour {
      * @param opts BrowserConfig
      * @param timeout Timeout (ms) if not device is found, default 10s
      * @param callback Callback when device found
-     * @returns 
+     * @returns
      */
     public findOne(opts: BrowserConfig | undefined = undefined, timeout = 10000, callback: CallableFunction): Browser {
         const browser: Browser = new Browser(this.server.mdns, opts)
@@ -67,7 +68,7 @@ export class Bonjour {
         }, timeout)
         return browser
     }
-      
+
     /**
      * Destroy the class
      */


### PR DESCRIPTION
Previously, any error being thrown by `MulticastDNS.respond` would not be handled at all:
https://github.com/onlxltd/bonjour-service/blob/c355b7259efaa2af4fc13859e527f25ea3ec3d87/src/lib/mdns-server.ts#L100-L102


This PR fixes that. iirc something similar was at some point proposed in the main repo 🤔