### PR TITLE
Export needed classes and precise type in publish signature

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ export class Bonjour {
      * @param onup Callback when up event received
      * @returns 
      */
-    public find(opts: BrowserConfig | undefined = undefined, onup?: (...args: any[]) => void): Browser {
+    public find(opts: BrowserConfig | undefined = undefined, onup?: (service: Service) => void): Browser {
         return new Browser(this.server.mdns, opts, onup)
     }
 
@@ -78,6 +78,6 @@ export class Bonjour {
 
 }
 
-export { Service, ServiceReferer, Browser }
+export { Service, ServiceReferer, ServiceConfig, Browser, BrowserConfig }
 
 export default Bonjour

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -43,7 +43,7 @@ export class Browser extends EventEmitter {
 
     private _services    : Array<any> = []
 
-    constructor(mdns: any, opts: any, onup?: (...args: any[]) => void) {
+    constructor(mdns: any, opts: any, onup?: (service: Service) => void) {
         super()
 
         if (typeof opts === 'function') return new Browser(mdns, null, opts)


### PR DESCRIPTION
This fixes unsafe imports when using types that are declared in the index.ts: BrowserConfig and ServiceConfig.
Also precise the onup parameter of `find` as it should always be a function taking a Service in parameter.