### PR TITLE
Filtered network addresses with invalid MAC addresses

### DIFF
--- a/src/lib/service.ts
+++ b/src/lib/service.ts
@@ -84,7 +84,7 @@ export class Service extends EventEmitter {
         for(let iface of ifaces) {
             let addrs : Array<os.NetworkInterfaceInfo> = iface
             for(let addr of addrs) {
-                if(addr.internal) continue
+                if(addr.internal || addr.mac === '00:00:00:00:00:00') continue
                 switch(addr.family) {
                     case 'IPv4':
                         records.push(this.RecordA(this, addr.address))


### PR DESCRIPTION
@mdidon Thanks for the great lib!

## Problem
Currently when publishing, the list of IP addresses is generated by looping through each network interfaces (except loopback) and adding its IP address. If the network interface is an L3 virtual `tun` device (used for VPNs), we shouldn't include these IPs in the response as they won't be accessible to the requester. 

## Solution
Filter out network addresses the have MAC address of `00:00:00:00:00:00`. This MAC address is used when the interface's MAC address can't be determined, as is expected for layer 3 interfaces.

## Additional Information
I was caught with the issue when publishing an mDNS service from a computer that also had an VPN connection set up on a `tun` network interface. The other machine who received the response saw the VPN's IP address in the list of IP's first, and assumed it was the IP address of the computer, but of course failed to connect.

Also I tested the same logic using [node_mdns](https://github.com/agnat/node_mdns) (which uses native C++ bindings), and it filters out my VPN interface as well. I couldn't find the exact logic that did this within their lib, but I assume it is similar to this PR.