### PR TITLE
Add `types` field to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "A Bonjour/Zeroconf implementation in TypeScript",
   "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "dependencies": {
     "array-flatten": "^2.1.2",
     "dns-equal": "^1.0.0",


### PR DESCRIPTION
This way, npm can detect it and show the _TypeScript Declarations included_ badge for the package.

I just spend 20 minutes searching for the typescript declarations until I noticed that they are already included ;-)