### PR TITLE
Support for mdns sub-type PTR record creation

### DIFF
--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -3,7 +3,7 @@ import DnsTxt                                                       from './dns-
 import dnsEqual                                                     from 'dns-equal'
 import { EventEmitter }                                             from 'events'
 import Service, { ServiceRecord }                                   from './service'
-import { toString as ServiceToString, toType as ServiceToType }     from './service-types'
+import { ServiceType, toString as ServiceToString, toType as ServiceToType } from './service-types'
 import filterService                                                from './utils/filter-service'
 import filterTxt                                                    from './utils/filter-txt'
 
@@ -78,15 +78,15 @@ export class Browser extends EventEmitter {
 
     public start() {
         if (this.onresponse || this.name === undefined) return
-        
+
         var self = this
-        
+
         // List of names for the browser to listen for. In a normal search this will
         // be the primary name stored on the browser. In case of a wildcard search
         // the names will be determined at runtime as responses come in.
         var nameMap: KeyValue = {}
         if (!this.wildcard) nameMap[this.name] = true
-    
+
         this.onresponse = (packet: any, rinfo: any) => {
             if (self.wildcard) {
                 packet.answers.forEach((answer: any) => {
@@ -95,33 +95,33 @@ export class Browser extends EventEmitter {
                     self.mdns.query(answer.data, 'PTR')
                 })
             }
-        
+
             Object.keys(nameMap).forEach(function (name) {
                 // unregister all services shutting down
                 self.goodbyes(name, packet).forEach(self.removeService.bind(self))
-            
+
                 // register all new services
                 var matches = self.buildServicesFor(name, packet, self.txt, rinfo)
                 if (matches.length === 0) return
-            
+
                 matches.forEach((service: Service) => {
                     if (self.serviceMap[service.fqdn]) return // ignore already registered services
                     self.addService(service)
                 })
             })
         }
-        
+
         this.mdns.on('response', this.onresponse)
         this.update()
     }
-    
+
     public stop() {
         if (!this.onresponse) return
-    
+
         this.mdns.removeListener('response', this.onresponse)
         this.onresponse = null
     }
-    
+
     public update() {
         this.mdns.query(this.name, 'PTR')
     }
@@ -129,7 +129,7 @@ export class Browser extends EventEmitter {
     public get services() {
         return this._services;
     }
-    
+
     private addService(service: Service) {
         // Test if service allowed by TXT query
         if(filterService(service, this.txtQuery) === false) return
@@ -168,16 +168,32 @@ export class Browser extends EventEmitter {
         .map((rr: ServiceRecord) => rr.data)
     }
 
+    // subytpes are in additional PTR records, with identical service names
+    //
+    // Note that only one subtype is allowed per record, but there may be multiple records
+    //
+    // For more info see:
+    // https://tools.ietf.org/html/rfc6763#section-7.1
+    //  Selective Instance Enumeration (Subtypes)
+    //
     private buildServicesFor(name: string, packet: any, txt: any, referer: any) {
         var records = packet.answers.concat(packet.additionals).filter( (rr: ServiceRecord) => rr.ttl > 0) // ignore goodbye messages
-      
+
         return records
           .filter((rr: ServiceRecord) => rr.type === 'PTR' && dnsEqual(rr.name, name))
           .map((ptr: ServiceRecord) => {
             const service: KeyValue = {
-              addresses: []
+              addresses: [],
+              subtypes: []
             }
-      
+
+            records.filter((rr: ServiceRecord) => {
+                return (rr.type === 'PTR' && dnsEqual(rr.data, ptr.data) && rr.name.includes('._sub'))
+              }).forEach((rr: ServiceRecord) => {
+                const types = ServiceToType(rr.name)
+                service.subtypes.push(types.subtype)
+            })
+
             records
               .filter((rr: ServiceRecord) => {
                 return (rr.type === 'SRV' || rr.type === 'TXT') && dnsEqual(rr.name, ptr.data)
@@ -194,24 +210,23 @@ export class Browser extends EventEmitter {
                   service.port = rr.data.port
                   service.type = types.name
                   service.protocol = types.protocol
-                  service.subtypes = types.subtypes
                 } else if (rr.type === 'TXT') {
                   service.rawTxt = rr.data
                   service.txt = this.txt.decodeAll(rr.data)
                 }
               })
-      
+
             if (!service.name) return
-      
+
             records
               .filter((rr: ServiceRecord) => (rr.type === 'A' || rr.type === 'AAAA') && dnsEqual(rr.name, service.host))
               .forEach((rr: ServiceRecord) => service.addresses.push(rr.data))
-      
+
             return service
           })
           .filter((rr: ServiceRecord) => !!rr)
       }
-      
+
 }
 
 export default Browser

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -3,7 +3,7 @@ import DnsTxt                                                       from './dns-
 import dnsEqual                                                     from 'dns-equal'
 import { EventEmitter }                                             from 'events'
 import Service, { ServiceRecord }                                   from './service'
-import { ServiceType, toString as ServiceToString, toType as ServiceToType } from './service-types'
+import { toString as ServiceToString, toType as ServiceToType }     from './service-types'
 import filterService                                                from './utils/filter-service'
 import filterTxt                                                    from './utils/filter-txt'
 

--- a/src/lib/service-types.ts
+++ b/src/lib/service-types.ts
@@ -4,13 +4,13 @@
 export interface ServiceType {
     name?       : string,
     protocol?   : 'tcp' | 'udp' | string | null | undefined,
-    subtypes?   : Array<string>
+    subtype?    : string | undefined
 }
 
 /**
  * Provides underscore prefix to name
- * @param name 
- * @returns 
+ * @param name
+ * @returns
  */
 const Prefix = (name: string): string => {
     return '_' + name
@@ -19,24 +19,24 @@ const Prefix = (name: string): string => {
 /**
  * Check if key is allowed
  * @param key
- * @returns 
+ * @returns
  */
 const AllowedProp = (key: string): boolean => {
-    let keys: Array<string> = ['name','protocol','subtypes']
+    let keys: Array<string> = ['name','protocol','subtype']
     return keys.includes(key)
 }
 
 /**
  * Format input ServiceType to string
- * @param data 
- * @returns 
+ * @param data
+ * @returns
  */
 export const toString = (data: ServiceType): any => {
     // Format to correct order
     let formatted: ServiceType = {
         name        : data.name,
         protocol    : data.protocol,
-        subtypes    : data.subtypes
+        subtype    : data.subtype
     }
     // Output as entries array
     let entries: Array<any> = Object.entries(formatted)
@@ -58,21 +58,29 @@ export const toString = (data: ServiceType): any => {
 
 /**
  * Format input string to ServiceType
- * @param string 
- * @returns 
+ * @param string
+ * @returns
  */
 export const toType = (string: string): ServiceType => {
     // Split string into parts by dot
-    var parts: Array<string> = string.split('.')
+    let parts: Array<string> = string.split('.')
+    let subtype: string | undefined;
+
     // Remove the prefix
     for(let i in parts) {
         if (parts[i][0] !== '_') continue
         parts[i] = parts[i].slice(1)
     }
+
+    if (parts.includes('sub')) {
+        subtype = parts.shift();
+        parts.shift();
+    }
+
     // Format the output
     return {
         name: parts.shift(),
         protocol: parts.shift() || null,
-        subtypes: parts
+        subtype: subtype
     }
 }

--- a/src/lib/service.ts
+++ b/src/lib/service.ts
@@ -69,7 +69,7 @@ export class Service extends EventEmitter {
         if (!config.name) throw new Error('ServiceConfig requires `name` property to be set');
         if (!config.type) throw new Error('ServiceConfig requires `type` property to be set');
         if (!config.port) throw new Error('ServiceConfig requires `port` property to be set');
-        
+
         this.name       = config.name
         this.protocol   = config.protocol || 'tcp'
         this.type       = ServiceToString({ name: config.type, protocol: this.protocol })
@@ -101,14 +101,19 @@ export class Service extends EventEmitter {
             }
         }
 
+        // Handle subtypes
+        for (let subtype of this.subtypes || []) {
+            records.push(this.RecordSubtypePTR(this, subtype));
+        }
+
         // Return all records
         return records
     }
 
     /**
      * Provide PTR record
-     * @param service 
-     * @returns 
+     * @param service
+     * @returns
      */
     private RecordPTR(service: Service): ServiceRecord {
         return {
@@ -120,9 +125,24 @@ export class Service extends EventEmitter {
     }
 
     /**
+     * Provide PTR record for subtype
+     * @param service
+     * @param subtype
+     * @returns
+     */
+     private RecordSubtypePTR(service: Service, subtype: string): ServiceRecord {
+        return {
+            name: `_${subtype}._sub.${service.type}${TLD}`,
+            type: 'PTR',
+            ttl: 28800,
+            data: `${service.name}.${service.type}${TLD}`
+        }
+    }
+
+    /**
      * Provide SRV record
-     * @param service 
-     * @returns 
+     * @param service
+     * @returns
      */
     private RecordSRV(service: Service): ServiceRecord {
         return {
@@ -138,8 +158,8 @@ export class Service extends EventEmitter {
 
     /**
      * Provide TXT record
-     * @param service 
-     * @returns 
+     * @param service
+     * @returns
      */
     private RecordTXT(service: Service): ServiceRecord {
         return {
@@ -152,9 +172,9 @@ export class Service extends EventEmitter {
 
     /**
      * Provide A record
-     * @param service 
-     * @param ip 
-     * @returns 
+     * @param service
+     * @param ip
+     * @returns
      */
     private RecordA(service: Service, ip: string): ServiceRecord {
         return {
@@ -169,7 +189,7 @@ export class Service extends EventEmitter {
      * Provide AAAA record
      * @param service
      * @param ip
-     * @returns 
+     * @returns
      */
     private RecordAAAA(service: Service, ip: string): ServiceRecord {
         return {

--- a/src/lib/service.ts
+++ b/src/lib/service.ts
@@ -84,6 +84,11 @@ export class Service extends EventEmitter {
     public records(): Array<ServiceRecord> {
         var records : Array<ServiceRecord>  = [this.RecordPTR(this), this.RecordSRV(this), this.RecordTXT(this)]
 
+        // Handle subtypes
+        for (let subtype of this.subtypes || []) {
+            records.push(this.RecordSubtypePTR(this, subtype));
+        }
+
         // Create record per interface address
         let ifaces  : Array<any> = Object.values(os.networkInterfaces())
         for(let iface of ifaces) {
@@ -99,11 +104,6 @@ export class Service extends EventEmitter {
                         break
                 }
             }
-        }
-
-        // Handle subtypes
-        for (let subtype of this.subtypes || []) {
-            records.push(this.RecordSubtypePTR(this, subtype));
         }
 
         // Return all records

--- a/test/bonjour.js
+++ b/test/bonjour.js
@@ -137,6 +137,21 @@ test('bonjour.find - binary txt', function (bonjour, t) {
   bonjour.publish({ name: 'Foo', type: 'test', port: 3000, txt: { bar: Buffer.from('buz') } }).on('up', next())
 })
 
+test('bonjour.find - subtypes', function (bonjour, t) {
+  const next = afterAll(function () {
+    const browser = bonjour.find({ type: 'test' })
+
+    browser.on('up', function (s) {
+      t.equal(s.name, 'Foo')
+      t.deepEqual(s.subtypes, ['foo', 'bar'])
+      bonjour.destroy()
+      t.end()
+    })
+  })
+
+  bonjour.publish({ name: 'Foo', type: 'test', port: 3000, subtypes: ['foo', 'bar'] }).on('up', next())
+})
+
 test('bonjour.find - down event', function (bonjour, t) {
   const service = bonjour.publish({ name: 'Foo Bar', type: 'test', port: 3000 })
 

--- a/test/service.js
+++ b/test/service.js
@@ -70,6 +70,12 @@ test('txt', function (t) {
   t.end()
 })
 
+test('subtypes', function (t) {
+  const s = new Service({ name: 'Foo Bar', type: 'http', port: 3000, subtypes: ['foo', 'bar'] })
+  t.deepEqual(s.subtypes, ['foo', 'bar'])
+  t.end()
+})
+
 test('_records() - minimal', function (t) {
   const s = new Service({ name: 'Foo Bar', type: 'http', protocol: 'tcp', port: 3000 })
   t.deepEqual(s.records(), [
@@ -81,11 +87,13 @@ test('_records() - minimal', function (t) {
 })
 
 test('_records() - everything', function (t) {
-  const s = new Service({ name: 'Foo Bar', type: 'http', protocol: 'tcp', port: 3000, host: 'example.com', txt: { foo: 'bar' } })
+  const s = new Service({ name: 'Foo Bar', type: 'http', protocol: 'tcp', port: 3000, host: 'example.com', txt: { foo: 'bar' }, subtypes: ['foo', 'bar'] })
   t.deepEqual(s.records(), [
     { data: s.fqdn, name: '_http._tcp.local', ttl: 28800, type: 'PTR' },
     { data: { port: 3000, target: 'example.com' }, name: s.fqdn, ttl: 120, type: 'SRV' },
-    { data: [Buffer.from('666f6f3d626172', 'hex')], name: s.fqdn, ttl: 4500, type: 'TXT' }
+    { data: [Buffer.from('666f6f3d626172', 'hex')], name: s.fqdn, ttl: 4500, type: 'TXT' },
+    { data: s.fqdn, name: '_foo._sub._http._tcp.local', ttl: 28800, type: 'PTR' },
+    { data: s.fqdn, name: '_bar._sub._http._tcp.local', ttl: 28800, type: 'PTR' }
   ].concat(getAddressesRecords(s.host)))
   t.end()
 })


### PR DESCRIPTION
After searching the history of bounjour-watson I found that there was some discussion of finalizing support for mdns sub-types in bonjour service, but it was never fullfilled/completed.  Since I need this support for my project, I have added the necessary PTR record generation to service.ts.
