### PR TITLE
Remove development files from NPM package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,7 @@
+.github
+examples
 node_modules
 src
 test
+.travis.yml
+tsconfig.json


### PR DESCRIPTION
Some of the files that end up in node_modules/bonjour-service are not needed at runtime, so they can be omitted from the package.
Whether to omit examples is a bit debatable: users that use bonjour-service directly probably would like them, but when bonjour-service is installed as a subdependency it will just be a waste of bytes.

Thanks for your consideration!