### PR TITLE
feat: `txt-update` event

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ Emitted every time a new service is found that matches the browser.
 
 Emitted every time an existing service emmits a goodbye message.
 
+#### `Event: txt-update`
+
+Emitted every time an existing service does a new announcement with an updated TXT record.
+
 #### `browser.services()`
 
 An array of services known by the browser to be online.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bonjour-service",
-  "version": "1.0.0",
+  "version": "1.0.4",
   "description": "A Bonjour/Zeroconf implementation in TypeScript",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -144,7 +144,7 @@ export class Browser extends EventEmitter {
 
     private updateService(service: Service) {
         // check if txt updated
-        if (equalTxt(service.txt, this._services.find((s) => dnsEqual(s.fqdn, service.fqdn))?.txt)) return
+        if (equalTxt(service.txt, this._services.find((s) => dnsEqual(s.fqdn, service.fqdn))?.txt || {})) return
         // if the new service is not allowed by the txt query, remove it
         if(!filterService(service, this.txtQuery)) {
             this.removeService(service.fqdn)

--- a/src/lib/utils/equal-txt.ts
+++ b/src/lib/utils/equal-txt.ts
@@ -1,0 +1,9 @@
+export default function equalTxt(a: Record<string, string>, b: Record<string, string>): boolean {
+    let aKeys = Object.keys(a)
+    let bKeys = Object.keys(b)
+    if(aKeys.length != bKeys.length) return false
+    for(let key of aKeys) {
+        if(a[key] != b[key]) return false
+    }
+    return true
+}


### PR DESCRIPTION
Hi @mdidon,
I have a device which contains a status in its TXT record. This changes and I need to detect it. However, `bonjour-service` would not emit an event if an announcement of an already discovered service was received, even if the TXT  record has changed.

This adds a new event called `txt-update` which is emitted if the TXT record has been updated.