### PR TITLE
feat: Add disableIpv6 ServiceConfig option

### DIFF
--- a/src/lib/service.ts
+++ b/src/lib/service.ts
@@ -21,6 +21,7 @@ export interface ServiceConfig {
     txt?        : KeyValue
 
     probe?      : boolean
+    disableIpv6?: boolean
 }
 
 export interface ServiceRecord {
@@ -78,6 +79,7 @@ export class Service extends EventEmitter {
         this.fqdn       = `${this.name}.${this.type}${TLD}`
         this.txt        = config.txt
         this.subtypes   = config.subtypes
+        this.disableIpv6 = !!config.disableIpv6
     }
 
 
@@ -100,6 +102,7 @@ export class Service extends EventEmitter {
                         records.push(this.RecordA(this, addr.address))
                         break
                     case 'IPv6':
+                        if (this.disableIpv6) break
                         records.push(this.RecordAAAA(this, addr.address))
                         break
                 }


### PR DESCRIPTION
Are you interested in adding the option to disable ipv6 for service advertisement? Our use-case is advertising a service that is bound to `0.0.0.0` e.g. it is not listening on a ipv6 address. I can look into adding tests if this is of interest. I'm not sure if any other places require modifications to support this option.