### PR TITLE
feat: Add optional callback for destroy() method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -71,10 +71,11 @@ export class Bonjour {
 
     /**
      * Destroy the class
+     * @param callback Callback when underlying socket is closed
      */
-    public destroy() {
+    public destroy(callback?: CallableFunction) {
         this.registry.destroy()
-        this.server.mdns.destroy()
+        this.server.mdns.destroy(callback)
     }
 
 }


### PR DESCRIPTION
Add an optional `callback` for the `bonjour.destroy()` method which will be called when the underlying socket is closed.