### PR TITLE
fix: fix error when calling service.start()

### DIFF
--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -52,9 +52,9 @@ export class Registry {
         }
         
         const service   = new Service(config)
-        service.start   = start.bind(null, service, this)
+        service.start   = start.bind(null, service, this, { probe: config.probe !== false })
         service.stop    = stop.bind(null, service, this)
-        service.start({ probe: config.probe !== false })
+        service.start()
         return service
     }
 


### PR DESCRIPTION
Currently `service.start()` must be called with `opts: { probe: boolean }`. This isn't documented. Two possible fixes:

- Update the docs to document the required parameter for `service.start(opts)`
- Integrate the change here which starts the service with the same config.probe that the service was created with.