### PR TITLE
Fix `BrowserConfig` interface props

### DIFF
--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -12,7 +12,7 @@ const TLD           = '.local'
 const WILDCARD      = '_services._dns-sd._udp' + TLD
 
 export interface BrowserConfig {
-    type        : string
+    type?        : string
     name?       : string
     protocol?   : 'tcp' | 'udp'
     subtypes?   : string[]


### PR DESCRIPTION
Fixes issue #49 by changing the definition of the `BrowserConfig` interface to treat `type` as an optional property. 