### PR TITLE
feat: track service ttl and lastSeen

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ Stop looking for matching services.
 
 Broadcast the query again.
 
+#### `browser.expire()`
+
+Check any services for an expired TTL and emit stop events.
+
 ### Service
 
 #### `Event: up`

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -95,17 +95,22 @@ export class Browser extends EventEmitter {
                 })
             }
 
+            const receiveTime = Date.now()
+
             Object.keys(nameMap).forEach(function (name) {
                 // unregister all services shutting down
                 self.goodbyes(name, packet).forEach(self.removeService.bind(self))
 
                 // register all new services
-                var matches = self.buildServicesFor(name, packet, self.txt, rinfo)
+                var matches = self.buildServicesFor(name, packet, self.txt, rinfo, receiveTime)
                 if (matches.length === 0) return
 
                 matches.forEach((service: Service) => {
-                    if (self.serviceMap[service.fqdn]) {
-                        self.updateService(service)
+                    const existingService = self._services.find((s) => dnsEqual(s.fqdn, service.fqdn))
+                    if (existingService) {
+                        // @ts-expect-error Types are wrong here
+                        existingService.lastSeen = service.lastSeen
+                        self.updateService(existingService, service)
                         return
                     }
                     self.addService(service)
@@ -140,9 +145,9 @@ export class Browser extends EventEmitter {
         this.emit('up', service)
     }
 
-    private updateService(service: Service) {
+    private updateService(existingService:Service, service: Service) {
         // check if txt updated
-        if (equalTxt(service.txt, this._services.find((s) => dnsEqual(s.fqdn, service.fqdn))?.txt || {})) return
+        if (equalTxt(service.txt, existingService.txt || {})) return
         // if the new service is not allowed by the txt query, remove it
         if(!filterService(service, this.txtQuery)) {
             this.removeService(service.fqdn)
@@ -194,7 +199,7 @@ export class Browser extends EventEmitter {
     // https://tools.ietf.org/html/rfc6763#section-7.1
     //  Selective Instance Enumeration (Subtypes)
     //
-    private buildServicesFor(name: string, packet: any, txt: KeyValue, referer: any) {
+    private buildServicesFor(name: string, packet: any, txt: KeyValue, referer: any, receiveTime: number) {
         var records = packet.answers.concat(packet.additionals).filter( (rr: ServiceRecord) => rr.ttl > 0) // ignore goodbye messages
 
         return records
@@ -202,7 +207,9 @@ export class Browser extends EventEmitter {
           .map((ptr: ServiceRecord) => {
             const service: KeyValue = {
               addresses: [],
-              subtypes: []
+              subtypes: [],
+              ttl: ptr.ttl,
+              lastSeen: receiveTime
             }
 
             records.filter((rr: ServiceRecord) => {

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -108,7 +108,6 @@ export class Browser extends EventEmitter {
                 matches.forEach((service: Service) => {
                     const existingService = self._services.find((s) => dnsEqual(s.fqdn, service.fqdn))
                     if (existingService) {
-                        // @ts-expect-error Types are wrong here
                         existingService.lastSeen = service.lastSeen
                         self.updateService(existingService, service)
                         return
@@ -137,17 +136,12 @@ export class Browser extends EventEmitter {
         const currentTime = Date.now()
 
         this._services = this._services.filter((service) => {
-            // @ts-expect-error Types are wrong here
-            if (!service.ttl) return true // No expiry
-            
-            // @ts-expect-error Types are wrong here
+            if(!service.ttl || service.lastSeen === undefined) return true // No expiry
             const expireTime = service.lastSeen + service.ttl * 1000
-
-            if (expireTime < currentTime) {
+            if(expireTime < currentTime) {
                 this.emit('down', service)
                 return false
             }
-
             return true
         })
     }

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -133,6 +133,25 @@ export class Browser extends EventEmitter {
         this.mdns.query(this.name, 'PTR')
     }
 
+    public expire() {
+        const currentTime = Date.now()
+
+        this._services = this._services.filter((service) => {
+            // @ts-expect-error Types are wrong here
+            if (!service.ttl) return true // No expiry
+            
+            // @ts-expect-error Types are wrong here
+            const expireTime = service.lastSeen + service.ttl * 1000
+
+            if (expireTime < currentTime) {
+                this.emit('down', service)
+                return false
+            }
+
+            return true
+        })
+    }
+
     public get services() {
         return this._services;
     }

--- a/src/lib/service.ts
+++ b/src/lib/service.ts
@@ -51,6 +51,8 @@ export class Service extends EventEmitter {
     public addresses?   : Array<string>
     public referer?     : ServiceReferer
     public disableIPv6  : boolean
+    public lastSeen?    : number
+    public ttl?         : number
 
     public probe        : boolean = true
 


### PR DESCRIPTION
This is a potential solution for #25

Currently the browser does not respect the TTL of the services it discovers.
Additionally, the only way to forget a service is for the remote to report that it is stopping, or to manually dispose and restart the browser.
This can easily lead to leaking memory, as some services do not report stopping, and there are many scenarios where they cannot (such as unclean shutdown or loss of network/power).

This attempts to resolve this is a non-breaking fashion.
To achieve this, we now track the ttl of the PTR record, and the last time we received the PTR record.
The user can then call an `expire` method, to trigger a check and purge of any services which have passed their ttl.

This makes an assumption that the ttl of each record is the same. If this is not the case, this could behave 'wrong' but I suspect that the current discovery could also get confused by that.