### PR TITLE
feat: add types to browser eventemitter

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "multicast-dns": "^7.2.5"
   },
   "devDependencies": {
-    "@types/node": "^16.18.11",
+    "@types/node": "^16.18.103",
     "@typescript-eslint/eslint-plugin": "^5.22.0",
     "@typescript-eslint/parser": "^5.22.0",
     "after-all": "^2.0.2",

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -21,6 +21,12 @@ export interface BrowserConfig {
 
 export type BrowserOnUp = (service: Service) => void
 
+export interface BrowserEvents {
+    up: [service: Service]
+    down: [service: Service]
+    'txt-update': [newService: Service]
+}
+
 /**
  * Start a browser
  *
@@ -36,7 +42,7 @@ export type BrowserOnUp = (service: Service) => void
  * with that service.
  */
 
-export class Browser extends EventEmitter {
+export class Browser extends EventEmitter<BrowserEvents> {
 
     private mdns        : any
     private onresponse  : CallableFunction | undefined  = undefined

--- a/yarn.lock
+++ b/yarn.lock
@@ -151,10 +151,10 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/node@^16.18.11":
-  version "16.18.58"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.58.tgz#bf66f63983104ed57c754f4e84ccaf16f8235adb"
-  integrity sha512-YGncyA25/MaVtQkjWW9r0EFBukZ+JulsLcVZBlGUfIb96OBMjkoRWwQo5IEWJ8Fj06Go3GHw+bjYDitv6BaGsA==
+"@types/node@^16.18.103":
+  version "16.18.103"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.103.tgz#5557c7c32a766fddbec4b933b1d5c365f89b20a4"
+  integrity sha512-gOAcUSik1nR/CRC3BsK8kr6tbmNIOTpvb1sT+v5Nmmys+Ho8YtnIHP90wEsVK4hTcHndOqPVIlehEGEA5y31bA==
 
 "@types/semver@^7.3.12":
   version "7.5.3"


### PR DESCRIPTION
For the past 6 months, @types/node has had support for using EventEmitter as a generic. https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68313

This PR utilises that, and allows for type safety and intellisense for these events.

It does require typescript users to update their @types/node to a version released since the end of february, but this should be a safe and easy extenral change for them to make.