### PR TITLE
feat: add `srv-update` event

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ Emitted every time a new service is found that matches the browser.
 
 Emitted every time an existing service emmits a goodbye message.
 
+#### `Event: srv-update`
+
+Emitted every time an existing service does a new announcement with an updated SRV record.
+
 #### `Event: txt-update`
 
 Emitted every time an existing service does a new announcement with an updated TXT record.


### PR DESCRIPTION
This is similar to #33

I have a device which will sometimes change the port number inside the SRV record. Currently this library doesn't notice that the port number has changed unless the device first emits a 'goodbye'

This makes it possible for consumers to detect these changes with the new event.