### PR TITLE
fix: Properly advertise service type for discovery in mDNS browsers.

### DIFF
--- a/src/lib/service.ts
+++ b/src/lib/service.ts
@@ -85,7 +85,12 @@ export class Service extends EventEmitter {
 
 
     public records(): Array<ServiceRecord> {
-        var records : Array<ServiceRecord>  = [this.RecordPTR(this), this.RecordSRV(this), this.RecordTXT(this)]
+        var records : Array<ServiceRecord>  = [
+            this.RecordPTR(this),
+            this.RecordSRV(this),
+            this.RecordTXT(this),
+            this.RecordServicePTR(this),
+        ]
 
         // Handle subtypes
         for (let subtype of this.subtypes || []) {
@@ -125,6 +130,20 @@ export class Service extends EventEmitter {
             type    : 'PTR',
             ttl     : 28800,
             data    : service.fqdn
+        }
+    }
+
+    /**
+     * Provide PTR record
+     * @param service
+     * @returns
+     */
+    private RecordServicePTR(service: Service): ServiceRecord {
+        return {
+            name    : `_services._dns-sd._udp${TLD}`,
+            type    : 'PTR',
+            ttl     : 120,
+            data    : `${service.type}${TLD}`
         }
     }
 

--- a/test/service.js
+++ b/test/service.js
@@ -81,7 +81,8 @@ test('_records() - minimal', function (t) {
   t.deepEqual(s.records(), [
     { data: s.fqdn, name: '_http._tcp.local', ttl: 28800, type: 'PTR' },
     { data: { port: 3000, target: os.hostname() }, name: s.fqdn, ttl: 120, type: 'SRV' },
-    { data: [], name: s.fqdn, ttl: 4500, type: 'TXT' }
+    { data: [], name: s.fqdn, ttl: 4500, type: 'TXT' },
+    { name: '_services._dns-sd._udp.local', type: 'PTR', ttl: 120, data: '_http._tcp.local' }
   ].concat(getAddressesRecords(s.host)))
   t.end()
 })
@@ -92,6 +93,7 @@ test('_records() - everything', function (t) {
     { data: s.fqdn, name: '_http._tcp.local', ttl: 28800, type: 'PTR' },
     { data: { port: 3000, target: 'example.com' }, name: s.fqdn, ttl: 120, type: 'SRV' },
     { data: [Buffer.from('666f6f3d626172', 'hex')], name: s.fqdn, ttl: 4500, type: 'TXT' },
+    { name: '_services._dns-sd._udp.local', type: 'PTR', ttl: 120, data: '_http._tcp.local' },
     { data: s.fqdn, name: '_foo._sub._http._tcp.local', ttl: 28800, type: 'PTR' },
     { data: s.fqdn, name: '_bar._sub._http._tcp.local', ttl: 28800, type: 'PTR' }
   ].concat(getAddressesRecords(s.host)))


### PR DESCRIPTION
Currently when I publish a service, some discovery apps and tools don't recognize the service using a global search query.

Note: Below commands are tested on macOS.

## Example code

```js
    mdns.publish({
        name,
        protocol: "tcp",
        type: "my-service",
        port: 502,
    });
```

## Before change:

Doesn't show up using global mDNS search command.
```sh
dns-sd -B _services._dns-sd._udp
```

Does show up when searching directly.
```sh
dns-sd -B _my-service._tcp
```

## After change:

Shows up on both above commands.

Also tested using the Discovery iOS app: https://apps.apple.com/us/app/discovery-dns-sd-browser/id305441017